### PR TITLE
fix: person operation in memory datastore

### DIFF
--- a/api/adaptors/memory/src/lib.rs
+++ b/api/adaptors/memory/src/lib.rs
@@ -43,7 +43,7 @@ impl Adaptor for MemoryAdaptor {
         let state = self.state.lock().await;
 
         // Event doesn't exist
-        if state.events.contains_key(&event_id) {
+        if !state.events.contains_key(&event_id) {
             return Ok(None);
         }
 
@@ -71,7 +71,7 @@ impl Adaptor for MemoryAdaptor {
         let mut state = self.state.lock().await;
 
         // Check event exists
-        if state.events.contains_key(&event_id) {
+        if !state.events.contains_key(&event_id) {
             return Ok(None);
         }
 


### PR DESCRIPTION
As pointed out in #1, the API fails when trying to login to fill in availability.

After investigation, it turns out that this only happens when using the Memory Datastore, because of two incorrect checks. Those where checking for the absence of an event instead of its existence, failing every login/fill requests with a `404 Not Found` error.

This behavior can easily be highlighted by running those command on a clean instance using Memory Datastore:

```
curl 'http://localhost:3000/event/event-385408' -i #404, since the instance is empty
curl 'http://localhost:3000/event/event-385408/people/John' -i #200, but should return the above error

curl 'http://localhost:3000/event' -X POST -H 'Content-Type: application/json' --data-raw '{"name":"","times":["0700-23092024","0800-23092024","0900-23092024","1000-23092024","1100-23092024","1200-23092024","1300-23092024","1400-23092024","0700-24092024","0800-24092024","0900-24092024","1000-24092024","1100-24092024","1200-24092024","1300-24092024","1400-24092024","0700-25092024","0800-25092024","0900-25092024","1000-25092024","1100-25092024","1200-25092024","1300-25092024","1400-25092024","0700-26092024","0800-26092024","0900-26092024","1000-26092024","1100-26092024","1200-26092024","1300-26092024","1400-26092024"],"timezone":"Europe/Zurich"}' #201, as expected
curl 'http://localhost:3000/event/event/<id>' -i #200, as expected
curl 'http://localhost:3000/event/<id>/people/John' -i #404, while it should succeed since the event exists
```

Closes #1